### PR TITLE
Update dependency xcb to the 1.2.0 release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "example"
 path = "examples/example.rs"
 
 [dependencies]
-xcb = {version="1.1", features=["xkb"], git="https://github.com/wez/rust-xcb", branch="ffi"}
+xcb = {version="1.2.0", features=["xkb"]}
 lazy_static = "1.4.0"
 bitflags = "1.3"
 


### PR DESCRIPTION
Tested in the Gentoo ebuild:

https://github.com/gentoo/gentoo/tree/master/x11-terms/wezterm

Signed-off-by: Mark Wright <gienah@gentoo.org>